### PR TITLE
change koa-logger to version 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "co-views": "^0.3.0",
     "koa": "^1.2.0",
     "koa-compress": "^1.0.8",
-    "koa-logger": "^2.0.0",
+    "koa-logger": "^1.3.0",
     "koa-route": "^2.4.0",
     "koa-static": "^2.0.0",
     "monk": "^1.0.0",


### PR DESCRIPTION
koa-logger 2.0.0 does not support koa version 1.   https://github.com/koajs/logger/tree/2.0.0
koa-logger 1.3.0 work properly.

I tested current master version in Ubuntu 14.04 x64, it showed:

> user@ubuntu:~/prtest/koa-rest$ npm run start
> 
> koa-rest@1.0.0 start /home/tutu/prtest/koa-rest
> node --harmony app.js
> 
> { [Error: Cannot find module '../build/Release/bson'] code: 'MODULE_NOT_FOUND' }
> js-bson: Failed to load c++ bson extension, using pure JS version
> 
> assert.js:89
>   throw new assert.AssertionError({
>   ^
> AssertionError: app.use() requires a generator function
>     at Application.app.use (/home/tutu/prtest/koa-rest/node_modules/koa/lib/application.js:106:5)
>     at Object.<anonymous> (/home/tutu/prtest/koa-rest/app.js:12:5)
>     at Module._compile (module.js:409:26)
>     at Object.Module._extensions..js (module.js:416:10)
>     at Module.load (module.js:343:32)
>     at Function.Module._load (module.js:300:12)
>     at Function.Module.runMain (module.js:441:10)
>     at startup (node.js:139:18)
>     at node.js:968:3
